### PR TITLE
[bug fix] if website is in subdirectory, the 'Logo' will link to wrong url

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ git pull
 ```r
 # Header
 menu:
-  Home: /
-  Archives: /archives
-  Categories: /categories # -> you need to add extra page to enable this, please see the config below.
-  Tags: /tags # -> you need to add extra page to enable this, please see the config below.
-  About: /about
+  Home: .
+  Archives: archives
+  Categories: categories # you need to add extra page to enable this, please see the config below.
+  Tags: tags             # you need to add extra page to enable this, please see the config below.
+  About: about
 
 # Content
 excerpt_link: Read More
@@ -58,7 +58,7 @@ contacts:
   twitter: '#'
   facebook: '#'
   dribbble: '#'
-  rss: /atom.xml
+  rss: atom.xml
 
 # Links
 links:
@@ -66,7 +66,7 @@ links:
 
 # Miscellaneous
 google_analytics:
-favicon: /favicon.png
+favicon: favicon.png
 twitter:
 google_plus:
 fb_admins:

--- a/_config.yml.example
+++ b/_config.yml.example
@@ -1,6 +1,6 @@
 # Header
 menu:
-  Home: /
+  Home: .
   Archives: archives
   Categories: categories
   Tags: tags
@@ -29,7 +29,7 @@ contacts:
   twitter: '#'
   facebook: '#'
   dribbble: '#'
-  rss: /atom.xml
+  rss: atom.xml
 
 # Links
 links:
@@ -37,7 +37,7 @@ links:
 
 # Miscellaneous
 google_analytics:
-favicon: /favicon.png
+favicon: favicon.png
 twitter:
 google_plus:
 fb_admins:

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,7 +1,7 @@
 <header id="header">
   <div id="header-main" class="header-inner">
     <div class="outer">
-      <a href="<%- url_for() %>" id="logo"><i class="logo"></i><span class="site-title"><%= config.title %></span></a>
+      <a href="<%- url_for('.') %>" id="logo"><i class="logo"></i><span class="site-title"><%= config.title %></span></a>
       <nav id="main-nav">
         <% for (var i in theme.menu){ %>
           <a class="main-nav-link" href="<%- url_for(theme.menu[i]) %>"><%= i %></a>


### PR DESCRIPTION
Example:
if website is `xxx.github.io/blog`, the `Logo` will link to `xxx.github.io/`

Solution:
replace path `/` to `.`

***Thanks for the wonderful theme!!***