### PR TITLE
Added `since` to the copyright line

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -4,7 +4,7 @@
   <% } %>
   <div class="outer">
     <div id="footer-info" class="inner">
-      &copy; <%= date(new Date(), 'YYYY') %> <%= config.author || config.title %><br>
+      &copy; <% if (config.since){ %><%= config.since %> - <% } %><%= date(new Date(), 'YYYY') %> <%= config.author || config.title %><br>
       Powered by <a href="http://hexo.io/" target="_blank">Hexo</a>. Theme by <a href="http://github.com/ppoffice">PPOffice</a>
     </div>
   </div>


### PR DESCRIPTION
The copyright could start from before. When the theme is used in a continuous blog, the posts could be written long before the current date.

To enable this function, a `since` should be set in the config file. For example, 

in `_config.yml`

```
since: 2012
```

Signed-off-by: Xiaofeng QU <xiaofeng.qu.hk@ieee.org>