### PR TITLE
Add a condition for the since config

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -4,7 +4,7 @@
   <% } %>
   <div class="outer">
     <div id="footer-info" class="inner">
-      &copy; <% if (config.since){ %><%= config.since %> - <% } %><%= date(new Date(), 'YYYY') %> <%= config.author || config.title %><br>
+      &copy; <% if (config.since && config.since != date(new Date(), 'YYYY')){ %><%= config.since %> - <% } %><%= date(new Date(), 'YYYY') %> <%= config.author || config.title %><br>
       Powered by <a href="http://hexo.io/" target="_blank">Hexo</a>. Theme by <a href="http://github.com/ppoffice">PPOffice</a>
     </div>
   </div>


### PR DESCRIPTION
Added a test of `config.since`. Just in case the `since` is the same as current year, avoiding showing `© 2015 - 2015`.

The code is not pretty. But I don't know how to set a variable in this case. Maybe someone could improve this?

Signed-off-by: Xiaofeng QU <xiaofeng.qu.hk@ieee.org>