### PR TITLE
Make article nav support i18n

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -8,6 +8,8 @@ index:
 nav:
   next: 'Next'
   prev: 'Prev'
+  older: 'Older'
+  newer: 'Newer'
 widget:
   recents: 'recents'
   archives: 'archives'

--- a/languages/id.yml
+++ b/languages/id.yml
@@ -8,6 +8,8 @@ index:
 nav:
   next: 'Berikutnya'
   prev: 'Sebelumnya'
+  older: 'Lebih Tua'
+  newer: 'Lebih baru'
 widget:
   recents: 'terbaru'
   archives: 'arsip'

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -8,6 +8,8 @@ index:
 nav:
   next: '下一页'
   prev: '上一页'
+  older: '下一篇'
+  newer: '上一篇'
 widget:
   recents: '最新文章'
   archives: '归档'

--- a/layout/_partial/post/nav.ejs
+++ b/layout/_partial/post/nav.ejs
@@ -2,7 +2,7 @@
 <nav id="article-nav">
   <% if (post.prev){ %>
     <a href="<%- url_for(post.prev.path) %>" id="article-nav-newer" class="article-nav-link-wrap">
-      <strong class="article-nav-caption">Newer</strong>
+      <strong class="article-nav-caption"><%= __('nav.newer') %></strong>
       <div class="article-nav-title">
         <% if (post.prev.title){ %>
           <%= post.prev.title %>
@@ -14,7 +14,7 @@
   <% } %>
   <% if (post.next){ %>
     <a href="<%- url_for(post.next.path) %>" id="article-nav-older" class="article-nav-link-wrap">
-      <strong class="article-nav-caption">Older</strong>
+      <strong class="article-nav-caption"><%= __('nav.older') %></strong>
       <div class="article-nav-title"><%= post.next.title %></div>
     </a>
   <% } %>


### PR DESCRIPTION
Make the “older” and “newer” links in article navigation support i18n
Indonesian translated by Google.