### PR TITLE
Page vs Post Differientiation

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -7,10 +7,12 @@
     <% if (post.link || post.title){ %>
       <header class="article-header">
         <%- partial('post/title', {class_name: 'article-title'}) %>
+        <% if(post.layout !== "page" { %>
         <div class="article-meta">
           <%- partial('post/date', {class_name: 'article-date', date_format: null}) %>
           <%- partial('post/category') %>
         </div>
+        <% } %>
       </header>
     <% } %>
     <div class="article-entry" itemprop="articleBody">


### PR DESCRIPTION
I think that posts and pages should be a little more different and one aspect that I delt with is getting rid of the date functionality for pages. I really don't want people to know when I decided to make a page because it is static, but I do want people to know when I created a post because it shows a progression over time (dynamic).