### PR TITLE
Add USTC CDN

### DIFF
--- a/layout/_partial/cdn_after_footer.ejs
+++ b/layout/_partial/cdn_after_footer.ejs
@@ -1,5 +1,7 @@
 <% if (theme.cdn == "useso"){ %>
  <script src="//ajax.useso.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+<% } else if (theme.cdn == "ustc") { %>
+ <script src="//ajax.lug.ustc.edu.cn/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <% } else { %>
  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <% } %>

--- a/layout/_partial/cdn_head.ejs
+++ b/layout/_partial/cdn_head.ejs
@@ -1,6 +1,9 @@
 <% if (theme.cdn == "useso"){ %>
  <link href='//fonts.useso.com/css?family=Open+Sans:400italic,400,600' rel='stylesheet' type='text/css'>
  <link href="//fonts.useso.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
+<% } else if (theme.cdn == "ustc") { %>
+ <link href='//fonts.lug.ustc.edu.cn/css?family=Open+Sans:400italic,400,600' rel='stylesheet' type='text/css'>
+ <link href="//fonts.lug.ustc.edu.cn/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
 <% } else { %>
  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,600' rel='stylesheet' type='text/css'>
  <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
As described in the article https://servers.ustclug.org/2014/06/blog-googlefonts-speedup/ , the Google libraries mirror service provided by USTC should be reasonably faster and more reliable than the one 360 offers, which even couldn't be correctly loaded over HTTPS due to certificate domain problem.