### PR TITLE
English spelling correction

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -11,7 +11,7 @@ nav:
     older: 'Older'
     newer: 'Newer'
 widget:
-    recents: 'recents'
+    recents: 'recent'
     archives: 'archives'
     categories: 'categories'
     links: 'links'


### PR DESCRIPTION
'recents' is not a work.  This should be 'recent'.