### PR TITLE
[bug fix] thumbnail refer to incorrect image url when site is put in a subdirectory

### DIFF
--- a/layout/common/thumbnail.ejs
+++ b/layout/common/thumbnail.ejs
@@ -1,7 +1,7 @@
 <a href="<%- url_for((post.link ? post.link : post.path)) %>" class="thumbnail">
     <% var thumbnailUrl = thumbnail(post) %>
     <% if (thumbnailUrl) { %>
-        <span style="background-image:url(<%- url_for(thumbnailUrl) %>)" alt="<%= post.title %>" class="thumbnail-image"></span>
+        <span style="background-image:url(<%= thumbnailUrl %>)" alt="<%= post.title %>" class="thumbnail-image"></span>
     <% } else { %>
         <span class="thumbnail-image thumbnail-none"></span>
     <% } %>


### PR DESCRIPTION
In `hexo@3.2.0`, the implementation of `url_for` has been changed.

Please help to check out whether this commit will cause any side-effect.
Thanks.

![no-image](https://cloud.githubusercontent.com/assets/2791834/14431150/f681bffe-0036-11e6-9125-7dcb8fddbe19.png)
