### PR TITLE
get insight content.json error

### DIFF
--- a/layout/search/insight.ejs
+++ b/layout/search/insight.ejs
@@ -21,7 +21,7 @@
             UNTITLED: '<%= __("insight.untitled") %>',
         },
         ROOT_URL: '<%= config.root %>',
-        CONTENT_URL: '<%- url_for("/content.json")%>',
+        CONTENT_URL: '<%- url_for("content.json")%>',
     };
     window.INSIGHT_CONFIG = INSIGHT_CONFIG;
 })(window);


### PR DESCRIPTION
当我在config中设置`root: /blog`的时候获取content.json 获取不到
<img width="498" alt="2016-04-16 6 19 50" src="https://cloud.githubusercontent.com/assets/8521368/14580460/38bef9b4-0400-11e6-881d-04ed1eea5cae.png">
我看了下页面的源代码，发现这里生成的并不是contents的实际路径
![image](https://cloud.githubusercontent.com/assets/8521368/14580469/6220d35e-0400-11e6-9983-eb581199bf54.png)
config的配置如下
![image](https://cloud.githubusercontent.com/assets/8521368/14580471/83cd6134-0400-11e6-8ec9-20d68ba60d39.png)
去掉content.json之前的`/`就OK了，不知道是我用得不对还是代码有什么问题