### PR TITLE
Fix Category Generate Error in Hexo 3.0

### DIFF
--- a/layout/common/post/category.ejs
+++ b/layout/common/post/category.ejs
@@ -1,7 +1,7 @@
 <% if (post.categories && post.categories.length) { %>
     <div class="article-category">
     	<i class="fa fa-folder"></i>
-        <%- list_categories(post.categories, {
+        <%- list_categories({
             show_count: false,
             class: 'article-category',
             style: 'none',


### PR DESCRIPTION
In Hexo 3.0, when you generate the site, the generator will report a bug. (Though it will not affect the generation)
The deleted codes will not influence the generation function.
【It seems that it is the change of the Hexo Func that causes this problem.

在Hexo3.0中，当你生成整站的时候，在原修改处会报错，虽然这并不影响生成器的后续工作。
修改的代码修复了以上的报错问题
【出现如上问题的原因似乎是Hexo 3.0中函数库发生了变化
