### PR TITLE
Minor improvements

### DIFF
--- a/_config.yml.example
+++ b/_config.yml.example
@@ -31,6 +31,7 @@ customize:
         facebook: /
         dribbble: /
         rss: /
+    social_link_tooltip: true # enable the social link tooltip, options: true, false
 
 # Widgets
 widgets:

--- a/layout/common/profile.ejs
+++ b/layout/common/profile.ejs
@@ -23,8 +23,13 @@
         <div class="profile-block social-links">
             <table>
                 <tr>
+                    <% var tooltipClass = theme.customize.social_link_tooltip === false ? '' : 'class=tooltip'; %>
                     <% for(var i in theme.customize.social_links) { %>
-                    <td><a href="<%- url_for(theme.customize.social_links[i]) %>" target="_blank" title="<%= i %>"><i class="fa fa-<%= i %>"></i></a></td>
+                    <td>
+                        <a href="<%- url_for(theme.customize.social_links[i]) %>" target="_blank" title="<%= i %>" <%= tooltipClass %>>
+                            <i class="fa fa-<%= i %>"></i>
+                        </a>
+                    </td>
                     <% } %>
                 </tr>
             </table>

--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -261,7 +261,7 @@
     background: none
     box-sizing: border-box
     font: 14px font-sans
-    padding: 0 15px
+    padding: 0 10px
     color: color-default
     outline: none
     border: 1px solid color-border

--- a/source/css/_partial/profile.styl
+++ b/source/css/_partial/profile.styl
@@ -87,6 +87,7 @@
                         color: color-default + #333
                         &:hover
                             color: color-default
+                        &.tooltip:hover
                             &:after
                                 right: -50%
                                 top: -41px


### PR DESCRIPTION
Just two minor fix/improvements:

1) There was a small space on the right side of the share box (see the image below) on Firefox (Windows and Ubuntu) and Chrome (Ubuntu only). I've fixed it just by reducing the text box padding.

![icarus-theme-minor-layout-fix-ok](https://cloud.githubusercontent.com/assets/19141172/15894740/eab5ef8e-2d5d-11e6-92fc-88536625f461.png)

2) I've included an option to enable or disable the social link tooltips. I've kept they enabled by default, even when the option is omitted. This way no one needs to modify their current config file to re-enable the tooltips.