### PR TITLE
Updated disqus script with configuration-variables

### DIFF
--- a/layout/comment/disqus.ejs
+++ b/layout/comment/disqus.ejs
@@ -1,20 +1,18 @@
 <% if (typeof(script) !== 'undefined' && script) { %>
     <script>
-    var disqus_shortname = '<%= theme.comment.disqus %>';
-    <% if (page.disqusId) { %>
-    var disqus_identifier = '<%= page.disqusId || page.slug %>';
-    <% } %>
-    <% if (page.permalink) { %>
-    var disqus_url = '<%= page.permalink %>';
-    <% } %>
-    (function() {
-    var dsq = document.createElement('script');
-    dsq.type = 'text/javascript';
-    dsq.async = true;
-    dsq.src = '//' + disqus_shortname + '.disqus.com/<% if (page.comments) { %>embed.js<% } else { %>count.js<% } %>';
-    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    var disqus_config = function () {
+        <% if (page.permalink) { %>
+            this.page.url = '<%= page.permalink %>';
+        <% } %>
+        this.page.identifier = '<%= page.disqusId || page.slug %>';
+    };
+    (function() { 
+        var d = document, s = d.createElement('script');  
+        s.src = '//' + '<%= theme.comment.disqus %>' + '.disqus.com/<% if (page.comments) { %>embed.js<% } else { %>count.js<% } %>';
+        s.setAttribute('data-timestamp', +new Date());
+        (d.head || d.body).appendChild(s);
     })();
-    </script>
+</script>
 <% } else { %>
     <div id="disqus_thread">
         <noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>


### PR DESCRIPTION
The `universal code` for disqus is as follows. The existing script template doesn't seems to be working.

```
<div id="disqus_thread"></div>
<script>
    /**
     *  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
     *  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables
     */
    /*
    var disqus_config = function () {
        this.page.url = PAGE_URL;  // Replace PAGE_URL with your page's canonical URL variable
        this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
    };
    */
    (function() {  // DON'T EDIT BELOW THIS LINE
        var d = document, s = d.createElement('script');
        
        s.src = '//' + disqus_shortname + '.disqus.com/embed.js';
        
        s.setAttribute('data-timestamp', +new Date());
        (d.head || d.body).appendChild(s);
    })();
</script>
<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
```

I have updated the script template matching with the `universal code`.

https://help.disqus.com/customer/en/portal/articles/2158629