### PR TITLE
Add an option to hide the date on pages

### DIFF
--- a/_config.yml.example
+++ b/_config.yml.example
@@ -32,6 +32,7 @@ customize:
         dribbble: /
         rss: /
     social_link_tooltip: true # enable the social link tooltip, options: true, false
+    hide_date_on_pages: false # hide the date on all pages (like the About page), options: true, false
 
 # Widgets
 widgets:

--- a/layout/common/post/date.ejs
+++ b/layout/common/post/date.ejs
@@ -1,4 +1,4 @@
-<% if (post.date) { %>
+<% if (post.date && (post.layout !== 'page' || !theme.customize.hide_date_on_pages)) { %>
     <div class="<%= class_name %>">
         <i class="fa fa-calendar"></i>
         <a href="<%- url_for(post.path) %>">


### PR DESCRIPTION
I've added an option to hide the date on all pages (only pages, not posts). The option is disabled by default.

Note: There was a more generic "hide date" feature in the pull request #29, but seem like that option is not available anymore.

