### PR TITLE
update blockquote position in article.styl

### DIFF
--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -93,7 +93,7 @@
         border-bottom: 1px solid color-border
         padding: 10px 0
     blockquote
-        position: relative
+        position: static
         font-family: font-serif
         font-size: 1.1em
         margin: 0 -20px
@@ -108,7 +108,7 @@
             font-size: 32px;
             font-family: FontAwesome
             text-align: center
-            position: absolute
+            position: static
         footer
             font-size: font-size
             margin: line-height 0


### PR DESCRIPTION
I found the blockquote obscures the toc directory.

Fix before:
![toc_unnormal](https://cloud.githubusercontent.com/assets/2291007/20958507/f9c8ba20-bc90-11e6-8d84-aa48f64b5901.png)


Fix after:
![toc_normal](https://cloud.githubusercontent.com/assets/2291007/20958530/0c865f6e-bc91-11e6-8262-8228b9f00c63.png)
