### PR TITLE
Added support for lazyloading of images

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -9,13 +9,13 @@
 
             // 对于已经包含在链接内的图片不适用lightGallery
             if ($(this).parent().prop("tagName") !== 'A') {
-                $(this).wrap('<a href="' + this.src + '" title="' + this.alt + '" class="gallery-item"></a>');
+                $(this).wrap('<a href="' + ($(this).attr("data-imgbig") ? $(this).attr("data-imgbig") : this.src) + '" title="' + this.alt + '" class="gallery-item"></a>');
             }
         });
     });
     if (typeof lightGallery != 'undefined') {
         var options = {
-            selector: '.gallery-item',
+            selector: '.gallery-item'
         };
         $('.article-entry').each(function(i, entry) {
             lightGallery(entry, options);


### PR DESCRIPTION
We can easily add lazy loading to the theme thanks to the builtin functionalities of lightGallery. Please see my post [here](https://alendev.hopto.org/myblog/Hexo/Icarus-Theme/lazyimages/2017/07/17/) to understand how you can optionally modify your markup to access this additional and optional functionality