### PR TITLE
Fix Potential Undefined Error in Comment Config Parsing

### DIFF
--- a/layout/comment/index.ejs
+++ b/layout/comment/index.ejs
@@ -13,7 +13,8 @@
         <section id="comments"><%- partial('comment/changyan') %></section>
     <% } else if (theme.comment.livere) { %>
         <section id="comments"><%- partial('comment/livere') %></section>
-    <% } else if (theme.comment.valine.on && 
+    <% } else if (theme.comment.valine && 
+        theme.comment.valine.on && 
         theme.comment.valine.appId && 
         theme.comment.valine.appKey) { %>
         <section id="comments"><%- partial('comment/valine') %></section>

--- a/layout/comment/scripts.ejs
+++ b/layout/comment/scripts.ejs
@@ -18,7 +18,8 @@
     <%- partial('comment/gitment', { script: true }) %>
 <% } else if (theme.comment.livere) { %>
     <%- partial('comment/livere', { script: true }) %>
-<% } else if (theme.comment.valine.on && 
+<% } else if (theme.comment.valine && 
+        theme.comment.valine.on && 
         theme.comment.valine.appId && 
         theme.comment.valine.appKey) { %>
     <%- partial('comment/valine', { script: true }) %>


### PR DESCRIPTION
Add preceding checks on `theme.comment.valine` to be compatible with the early configuration template.

Resolves #302.