### PR TITLE
Update mathjax.ejs

### DIFF
--- a/layout/plugin/mathjax.ejs
+++ b/layout/plugin/mathjax.ejs
@@ -1,12 +1,14 @@
 <% if (!head && plugin !== false) { %>
 <%- _js(cdn('mathjax', '2.7.5', 'unpacked/MathJax.js?config=TeX-MML-AM_CHTML'), true) %>
 <script>
-document.addEventListener('DOMContentLoaded', function () {
     MathJax.Hub.Config({
-        'HTML-CSS': {matchFontHeight: false},
+        tex2jax: {inlineMath: [['$', '$']], displayMath: [['$$', '$$']]},
+        TeX: {equationNumbers: {autoNumber: "AMS"},
+              showProcessingMessages: false,
+              messageStyle: 'none'},
+        "HTML-CSS": {matchFontHeight: false},
         SVG: {matchFontHeight: false},
         CommonHTML: {matchFontHeight: false}
     });
-});
 </script>
 <% } %>

--- a/layout/plugin/mathjax.ejs
+++ b/layout/plugin/mathjax.ejs
@@ -1,6 +1,7 @@
 <% if (!head && plugin !== false) { %>
 <%- _js(cdn('mathjax', '2.7.5', 'unpacked/MathJax.js?config=TeX-MML-AM_CHTML'), true) %>
 <script>
+document.addEventListener('DOMContentLoaded', function () {
     MathJax.Hub.Config({
         tex2jax: {inlineMath: [['$', '$']], displayMath: [['$$', '$$']]},
         TeX: {equationNumbers: {autoNumber: "AMS"},
@@ -10,5 +11,6 @@
         SVG: {matchFontHeight: false},
         CommonHTML: {matchFontHeight: false}
     });
+ });
 </script>
 <% } %>


### PR DESCRIPTION
- Using sigle `$` in inline equation and double `$` to represente the equation block.
- equation auto number