### PR TITLE
Open Icarus page in a new tab

### DIFF
--- a/layout/common/footer.ejs
+++ b/layout/common/footer.ejs
@@ -12,7 +12,7 @@
                 <p class="is-size-7">
                 &copy; <%= date(new Date(), 'YYYY') %> <%= get_config('author') || get_config('title') %>&nbsp;
                 Powered by <a href="http://hexo.io/" target="_blank">Hexo</a> & <a
-                        href="http://github.com/ppoffice/hexo-theme-icarus">Icarus</a>
+                        href="http://github.com/ppoffice/hexo-theme-icarus" target="_blank">Icarus</a>
                 </p>
             </div>
             <div class="level-end">


### PR DESCRIPTION
Trivial change to open Icarus github repo link in a new tab from footer