### PR TITLE
Make follow link in profile widget be opened in new tab

### DIFF
--- a/layout/widget/profile.ejs
+++ b/layout/widget/profile.ejs
@@ -73,7 +73,7 @@
             </div>
         </nav>
         <div class="level">
-            <a class="level-item button is-link is-rounded" href="<%= url_for(widget.follow_link) %>">
+            <a class="level-item button is-link is-rounded" href="<%= url_for(widget.follow_link) %>" target="_blank">
                 <%= __('widget.follow') %></a>
         </div>
         <% const socialLinks = get_config_from_obj(widget, 'social_links'); %>


### PR DESCRIPTION
I believe it's more user-friendly to open the follow link in a new tab, as viewers may want to view other contents of the website.