### PR TITLE
To show author info below the title.

### DIFF
--- a/layout/common/article.ejs
+++ b/layout/common/article.ejs
@@ -44,6 +44,7 @@
                 <%= post.title %>
             <% } %>
         </h1>
+        <%- partial('author.ejs') %>
         <div class="content">
             <%- index && post.excerpt ? post.excerpt : post.content %>
         </div>

--- a/layout/common/author.ejs
+++ b/layout/common/author.ejs
@@ -1,0 +1,8 @@
+<% if (post.author) { %>
+
+<div class="level-left author">
+    <span class="level-item has-text-grey">
+       <a style="color: grey" href="#"> <%- post.author %></a>
+    </span>
+</div>
+<% } %>

--- a/source/css/style.styl
+++ b/source/css/style.styl
@@ -444,3 +444,13 @@ figure.highlight
             border: none
     .file
         all: initial
+
+/* ---------------------------------
+ *        Author Snippet
+ * --------------------------------- */
+ .title
+     margin-bottom : 5px!important;
+
+.author
+    padding : 2px;
+    margin-bottom : 1.5rem!important;


### PR DESCRIPTION
#453 
This will allow users to show author name under the post. In case there are multiple author working on the same site. it will give personalisation feel on the blog. 

See the below sample 
<img width="1226" alt="Screenshot 2019-05-02 at 1 23 50 AM" src="https://user-images.githubusercontent.com/14224107/57031014-0c9d7880-6c79-11e9-9770-64746beda668.png">
