### PR TITLE
Add subscribe email widget

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -19,6 +19,9 @@ widget:
     links: 'Links'
     tag_cloud: 'Tag Cloud'
     catalogue: 'Catalogue'
+    email:
+        title: 'Subscribe Email'
+        button: 'Subscribe'
 article:
     more: 'Read More'
     comments: 'Comments'

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -19,6 +19,9 @@ widget:
     links: '連結'
     tag_cloud: '標籤雲'
     catalogue: '文章目錄'
+    email:
+        title: '訂閱 Email'
+        button: '訂閱'
 article:
     more: '繼續閱讀'
     comments: '評論'

--- a/layout/widget/subscribe_email.ejs
+++ b/layout/widget/subscribe_email.ejs
@@ -1,0 +1,30 @@
+<div class="card widget">
+  <div class="card-content">
+    <div class="menu">
+      <h3 class="menu-label">
+        <%= __('widget.email.title') %>
+      </h3>
+      <div>
+        <form action="https://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow"
+          onsubmit="window.open('https://feedburner.google.com/fb/a/mailverify?uri=<%= get_config_from_obj(widget, 'feedburner_id') %>', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true">
+          <input type="hidden" value="<%= get_config_from_obj(widget, 'feedburner_id') %>" name="uri" />
+          <input type="hidden" name="loc" value="en_US" />
+          <div class="field">
+            <div class="control has-icons-left">
+              <input class="input" name="email" type="email" />
+              <span class="icon is-small is-left">
+                <i class="fas fa-envelope"></i>
+              </span>
+            </div>
+            <p class="help"><%= get_config_from_obj(widget, 'description') %></p>
+          </div>
+          <div class="field is-grouped is-grouped-right">
+            <div class="control">
+              <input class="button is-primary" type="submit" value="<%= __('widget.email.button') %>" />
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/layout/widget/subscribe_email.locals.js
+++ b/layout/widget/subscribe_email.locals.js
@@ -1,0 +1,3 @@
+module.exports = (ctx, locals) => {
+    return locals;
+}


### PR DESCRIPTION
Add a subscribe email widget currently only support [feedburner](https://feedburner.google.com)
Live Demo: https://blog.liyang.info


<img width="413" alt="Screen Shot 2019-10-29 at 9 05 04 PM" src="https://user-images.githubusercontent.com/13155472/67769636-d017d180-fa8f-11e9-94c8-06e0b86312d0.png">

config example
```yml
widgets:
    -
        # Widget name
        type: subscribe_email
        feedburner_id: LiyangsBlog
        description: 現在就訂閱，新知不漏接
        position: right

```