### PR TITLE
show edited time at the top of the article

### DIFF
--- a/includes/specs/article.spec.js
+++ b/includes/specs/article.spec.js
@@ -31,5 +31,10 @@ module.exports = {
         [type]: 'boolean',
         [doc]: 'Whether to show estimate article reading time',
         [defaultValue]: true
+    },
+    updated: {
+        [type]: 'boolean',
+        [doc]: 'Whether to show article edit time',
+        [defaultValue]: false
     }
 };

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -28,6 +28,7 @@ article:
     read: 'read'
     about: 'About'
     words: 'words'
+    edited: 'edited'
 donate:
     title: 'Like this article? Support the author with'
     alipay: 'Alipay'

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -25,6 +25,7 @@ article:
     read: '读完'
     about: '大约'
     words: '个字'
+    edited: '编辑于'
 donate:
     title: '喜欢这篇文章？打赏一下作者吧'
     alipay: '支付宝'

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -28,6 +28,7 @@ article:
     read: '閱讀文'
     about: '大約'
     words: '個字'
+    edited: '編輯于'
 donate:
     title: '喜歡這篇文章嗎? 贊助一下作者吧!'
     alipay: '支付寶'

--- a/layout/common/article.ejs
+++ b/layout/common/article.ejs
@@ -11,9 +11,9 @@
         <% if (post.layout != 'page') { %>
         <div class="level article-meta is-size-7 is-uppercase is-mobile is-overflow-x-auto">
             <div class="level-left">
-                <time class="level-item has-text-grey" datetime="<%= date_xml(post.date) %>"><%= date(post.date) %></time>
+                <time class="level-item has-text-grey" title="<%= post.date %>" datetime="<%= date_xml(post.date) %>"><%= date(post.date) %></time>
                 <% if (get_config('article.updated') === true && post.updated - post.date !== 0) { %>
-                <span class="level-item has-text-grey">
+                <span class="level-item has-text-grey" title="<%= post.updated %>">
                     <%= __('article.edited') %>&nbsp;
                     <time datetime="<%= date_xml(post.updated) %>"><%= date(post.updated) %></time>
                 </span>

--- a/layout/common/article.ejs
+++ b/layout/common/article.ejs
@@ -12,6 +12,12 @@
         <div class="level article-meta is-size-7 is-uppercase is-mobile is-overflow-x-auto">
             <div class="level-left">
                 <time class="level-item has-text-grey" datetime="<%= date_xml(post.date) %>"><%= date(post.date) %></time>
+                <% if (get_config('article.updated') === true && post.updated - post.date !== 0) { %>
+                <span class="level-item has-text-grey">
+                    <%= __('article.edited') %>&nbsp;
+                    <time datetime="<%= date_xml(post.updated) %>"><%= date(post.updated) %></time>
+                </span>
+                <% } %>
                 <% if (post.categories && post.categories.length) { %>
                 <div class="level-item">
                 <%- list_categories(post.categories, {


### PR DESCRIPTION
### Task
- [x] 1. Show edited time at the top of the article when edited time is different with created time.
- [ ] 2. Full language support.
- [x] 3. Show absolute time when user hover on relative time.
- [ ] 4. Show a yellow bar about edited time information. (just like the image in #437)

### Preview
![show-edit](https://user-images.githubusercontent.com/20182252/68538521-a4121f80-03b0-11ea-9a29-3836947bfa69.png)

@ppoffice
I can not finish task 2 without help, and I am not sure whether we need to implement task 4