### PR TITLE
chore(*): fix mistranslated word

### DIFF
--- a/languages/ko.yml
+++ b/languages/ko.yml
@@ -23,7 +23,7 @@ article:
     more: '자세히 보기'
     comments: '댓글'
     read: '읽기'
-    about: '나에 대하여'
+    about: '대략'
     words: '단어'
 search:
     search: '검색'


### PR DESCRIPTION
Maybe previous translator misunderstood `about` words.
In this context, that translation means 'about me' not 'about XX words'.