### PR TITLE
feat(spec): add canonical_url spec

### DIFF
--- a/includes/specs/meta.spec.js
+++ b/includes/specs/meta.spec.js
@@ -15,6 +15,11 @@ module.exports = {
             [doc]: 'Meta tag specified in <attribute>=<value> style.\nE.g., name=theme-color;content=#123456 => <meta name="theme-color" content="#123456">'
         }
     },
+    canonical_url: {
+        [type]: 'string',
+        [doc]: 'canonical_url of your site',
+        [defaultValue]: null
+    },
     rss: {
         [type]: 'string',
         [doc]: 'Path or URL to RSS atom.xml',


### PR DESCRIPTION
Already added `canonical_url` config by #436.
But because config spec is missing, auto-generated config dosen't generate `canonical_url`.
Added `canonical_url` to config spec.