### PR TITLE
fix(cdn): default valine cdn response is slow and unstable

### DIFF
--- a/layout/comment/valine.ejs
+++ b/layout/comment/valine.ejs
@@ -5,7 +5,7 @@
 <% } else { %>
 <div id="valine-thread" class="content"></div>
 <script src="//cdn1.lncld.net/static/js/3.0.4/av-min.js"></script>
-<script src='//unpkg.com/valine/dist/Valine.min.js'></script>
+<%- _js(cdn('valine', '1.3.10', 'dist/Valine.min.js')) %>
 <script>
     new Valine({
         el: '#valine-thread' ,


### PR DESCRIPTION
## Problem

Valine default CDN is really slow and unstable. Js file load failure causes blocked page rendering. 

I've been meet it many times in a few days. So it‘s a very bad experience for site user.

Screenshot as follows:

![image](https://user-images.githubusercontent.com/26399528/71394781-074cce00-264e-11ea-857a-f5b95c93fdb1.png)

## Solution

Use theme default cdn `jsdelivr`. The test result is satisfactory, at least without failure.

Screenshot as follows:

![image](https://user-images.githubusercontent.com/26399528/71394958-d4efa080-264e-11ea-90c4-6d6d447e7a5e.png)

