### PR TITLE
refactor(cdn.js): reduce unnecessary branch

### DIFF
--- a/includes/helpers/cdn.js
+++ b/includes/helpers/cdn.js
@@ -31,26 +31,30 @@ module.exports = function (hexo) {
             if (filename.startsWith('dist/')) {
                 filename = filename.substr(5);
             }
-            if (_package === 'moment') {
-                _package = 'moment.js';
-                filename = filename.startsWith('min/') ? filename.substr(4) : filename;
-            }
-            if (_package === 'outdatedbrowser') {
-                _package = 'outdated-browser';
-                filename = filename.startsWith('outdatedbrowser/') ? filename.substr(16) : filename;
-            }
-            if (_package === 'highlight.js') {
-                filename = filename.endsWith('.css') && filename.indexOf('.min.') === -1 ?
-                    filename.substr(0, filename.length - 4) + '.min.css' : filename;
-            }
-            if (_package === 'mathjax') {
-                filename = filename.startsWith('unpacked/') ? filename.substr(9) : filename;
-            }
-            if (_package === 'pace-js') {
-                _package = 'pace';
-            }
-            if (_package === 'clipboard') {
-                _package = 'clipboard.js';
+            switch (_package) {
+                case "moment":
+                    _package = 'moment.js';
+                    filename = filename.startsWith('min/') ? filename.substr(4) : filename;
+                    break;
+                case "outdatedbrowser":
+                    _package = 'outdated-browser';
+                    filename = filename.startsWith('outdatedbrowser/') ? filename.substr(16) : filename;
+                    break;
+                case "highlight.js":
+                    filename = filename.endsWith('.css') && filename.indexOf('.min.') === -1 ?
+                        filename.substr(0, filename.length - 4) + '.min.css' : filename;
+                    break;
+                case "mathjax":
+                    filename = filename.startsWith('unpacked/') ? filename.substr(9) : filename;
+                    break;
+                case "pace-js":
+                    _package = 'pace';
+                    break;
+                case "clipboard":
+                    _package = 'clipboard.js';
+                    break;
+                default:
+                    break;
             }
         }
         if (provider !== null && cdn_providers.hasOwnProperty(provider)) {

--- a/layout/comment/valine.ejs
+++ b/layout/comment/valine.ejs
@@ -5,7 +5,7 @@
 <% } else { %>
 <div id="valine-thread" class="content"></div>
 <script src="//cdn1.lncld.net/static/js/3.0.4/av-min.js"></script>
-<script src='//unpkg.com/valine/dist/Valine.min.js'></script>
+<%- _js(cdn('valine', '1.3.10', 'dist/Valine.min.js')) %>
 <script>
     new Valine({
         el: '#valine-thread' ,


### PR DESCRIPTION
In `includes/helpers/cdn.js`, the cdn register did many unnecessary judgment branch. They should be replaced by `if / else if / else` or `switch`