### PR TITLE
fix(plugin): remove visitor counter from article list

### DIFF
--- a/layout/common/article.jsx
+++ b/layout/common/article.jsx
@@ -60,7 +60,7 @@ module.exports = class extends Component {
                                 })()}
                             </span> : null}
                             {/* Visitor counter */}
-                            {plugins && plugins.busuanzi === true ? <span class="level-item" id="busuanzi_container_page_pv" dangerouslySetInnerHTML={{
+                            {!index && plugins && plugins.busuanzi === true ? <span class="level-item" id="busuanzi_container_page_pv" dangerouslySetInnerHTML={{
                                 __html: '<i class="far fa-eye"></i>' + _p('plugin.visit', '&nbsp;&nbsp;<span id="busuanzi_value_page_pv">0</span>')
                             }}></span> : null}
                         </div>


### PR DESCRIPTION
In article list page, visitor counts for articles is incorrect, the first article shows a large count of visitors, and others shows a count of 0.

Such as:

Article 1 ... 👀1234
Article 2 ... 👀0
Article 3 ... 👀0
......

We can only see the correct visitors count after click into the article.

We may remove visitor counter from article list, should we? @ppoffice 