### PR TITLE
Add Utterances comment system

### DIFF
--- a/includes/specs/comment.spec.js
+++ b/includes/specs/comment.spec.js
@@ -124,6 +124,33 @@ const ValineSpec = {
     }
 };
 
+const UtterancesSpec = {
+    repo: {
+        [type]: 'string',
+        [doc]: 'The repository willed connect to utterances',
+        [required]: true,
+        [requires]: comment => comment.type === 'utterances'
+    },
+    issue_term: {
+        [type]: 'string',
+        [doc]: 'Blog Post ↔️ Issue Mapping',
+        [defaultValue]: 'pathname',
+        [requires]: comment => comment.type === 'utterances'
+    },
+    label: {
+        [type]: 'string',
+        [doc]: 'Issue Label',
+        [defaultValue]: '',
+        [requires]: comment => comment.type === 'utterances'
+    },
+    theme: {
+        [type]: 'string',
+        [doc]: 'Utterances theme',
+        [defaultValue]: 'github-light',
+        [requires]: comment => comment.type === 'utterances'
+    }
+};
+
 module.exports = {
     [type]: 'object',
     [doc]: 'Comment plugin settings\nhttps://ppoffice.github.io/hexo-theme-icarus/categories/Plugins/Comment',
@@ -137,5 +164,6 @@ module.exports = {
     ...GitmentGitalkSpec,
     ...IssoSpec,
     ...LiveReSpec,
-    ...ValineSpec
+    ...ValineSpec,
+    ...UtterancesSpec
 }

--- a/layout/comment/utterances.ejs
+++ b/layout/comment/utterances.ejs
@@ -1,0 +1,14 @@
+<% if (!has_config('comment.repo')) { %>
+<div class="notification is-danger">
+    You forgot to set the <code>repo</code> for utteranc.es Please set it in <code>_config.yml</code>.
+</div>
+<% } else { %>
+<script src="https://utteranc.es/client.js"
+        repo="<%= get_config('comment.repo') %>"
+        issue-term="<%= get_config('comment.issue-term') %>"
+        label="<%= get_config('comment.label') %>"
+        theme="<%= get_config('comment.theme') %>"
+        crossorigin="anonymous"
+        async>
+</script>
+<% } %>

--- a/layout/comment/utterances.locals.js
+++ b/layout/comment/utterances.locals.js
@@ -1,0 +1,3 @@
+module.exports = (ctx, locals) => {
+    return locals;
+}


### PR DESCRIPTION
## utterances 🔮
A lightweight comments widget built on GitHub issues. Use GitHub issues for blog comments, wiki pages and more!

- [Open source](https://github.com/utterance). 🙌
- No tracking, no ads, always free. 📡🚫
- No lock-in. All data stored in GitHub issues. 🔓
- Styled with [Primer](http://primer.style/), the css toolkit that powers GitHub. 💅
- Dark theme. 🌘
- Lightweight. Vanilla TypeScript. No font downloads, JavaScript frameworks or polyfills for evergreen browsers. 🐦🌲

**Please refer to the [official website](https://utteranc.es/) for usage and demonstration effect**

![截屏2020-02-17下午9 32 41](https://user-images.githubusercontent.com/7850715/74658564-89302200-51cd-11ea-8bca-00f4d8894cfa.png)
![截屏2020-02-17下午9 33 42](https://user-images.githubusercontent.com/7850715/74658538-7fa6ba00-51cd-11ea-8440-e41aea325cf5.png)

Example for`_config.yml`
```yaml
comment:
    # Name of the comment plugin
    type: utterances
    repo: <username/repo>
    issue-term: pathname
    label: comment
    theme: github-light
```