### PR TITLE
fix: code tag text overflow-wrap

### DIFF
--- a/include/style/article.styl
+++ b/include/style/article.styl
@@ -50,6 +50,7 @@ article
             code
                 padding: 0
                 background: transparent
+                overflow-wrap: break-word
 
             blockquote
                 &.pullquote


### PR DESCRIPTION
Long content in `<code>`  will overflow and cause horizontal scrollbar on mobile phones