### PR TITLE
fix(style): improve MathJax and KaTeX

### DIFF
--- a/include/style/plugin.styl
+++ b/include/style/plugin.styl
@@ -80,3 +80,32 @@
  * --------------------------------- */
 .fa, .fab, .fal, .far, .fas
     line-height: inherit
+
+/* ---------------------------------
+ *       MathJax and KaTeX
+ * --------------------------------- */
+.MathJax, .katex-display
+    overflow-x: auto
+    overflow-y: hidden
+
+.katex
+    white-space: nowrap
+
+.katex-display
+    margin-top: -1em !important
+
+.katex-html
+    padding-top: 1em
+    .tag
+        align-items: unset
+        background-color: unset
+        border-radius: unset
+        color: unset
+        display: unset
+        font-size: unset
+        height: unset
+        justify-content: unset
+        line-height: unset
+        padding-left: unset
+        padding-right: unset
+        white-space: unset


### PR DESCRIPTION
做了以下四点改进：

首先，由于数学公式(MathJax & KaTeX)在移动端容易出现水平方向超长的状况，该改进自动加入水平滚动条；

其次，数学公式(KaTeX)在某些移动端会出现顶部显示不全的状况，该改进通过增加上方内边距(padding-top)，减少上方外边距(margin-top)来解决该问题，由于增加和减少的边距相同，该变动不会造成其它的排版上的影响；

再来，内联的数学公式(KaTeX)可能在公式中的任意位置换行，这是我们不想看到的，所以该改进禁止其换行(whitespace: nowrap;)

最后，如果在数学公式(KaTeX)中使用 `\tag{...}` 给公式编号，最后生成的公式中会对应地产生一个 class 为 `.tag` 的 HTML 标签。不巧的是 bulma 框架中规定了 `.tag` 的样式，这会使公式的标签看上去很奇怪，所以该改进将本不该有的对于 `.tag` 的样式设定为了 unset 来解决该问题。