### PR TITLE
fix(css): search box height issue on chrome 71

### DIFF
--- a/include/style/search.styl
+++ b/include/style/search.styl
@@ -81,6 +81,9 @@ $searchbox-bg-pagination-item-disabled ?= $searchbox-bg-container
         line-height: 1.5em
         font-weight: normal
         background-color: $searchbox-bg-input
+        // fix Chrome 71 height issue
+        // https://github.com/ppoffice/hexo-theme-icarus/issues/719
+        min-height: 3rem
 
     .searchbox-input-container
         display: flex


### PR DESCRIPTION
#719

Tested with

1. Windows + Chrome 71
2. Windows + Chrome 81
3. Windows + Firefox 76
4. Android + Chrome 71
5. Android + Wechat browser
6. iPad OS + Safari