### PR TITLE
Support config widget in each page

### DIFF
--- a/layout/layout.jsx
+++ b/layout/layout.jsx
@@ -12,7 +12,7 @@ module.exports = class extends Component {
         const { env, site, config, page, helper, body } = this.props;
 
         const language = page.lang || page.language || config.language;
-        const columnCount = Widgets.getColumnCount(config.widgets);
+        const columnCount = Widgets.getColumnCount(config.widgets, page);
 
         return <html lang={language ? language.substr(0, 2) : ''}>
             <Head env={env} site={site} config={config} helper={helper} page={page} />


### PR DESCRIPTION
How to use:
```
widgets:
    # Profile widget configurations
    -
        # Where should the widget be placed, left sidebar or right sidebar
        position: left
        type: profile
   		# ...
   		# Specified pages that will show the widget, all pages by default. eg: index, archive, category, tag, post
        pages:
            - index
	# ...
    # Table of contents widget configurations
    -
        # Where should the widget be placed, left sidebar or right sidebar
        position: right
        type: toc
        pages:
            - post
    # Recent posts widget configurations
    -
        # Where should the widget be placed, left sidebar or right sidebar
        position: right
        type: recent_posts
    # Categories widget configurations
    -
        # Where should the widget be placed, left sidebar or right sidebar
        position: right
        type: categories
    # Tags widget configurations
    -
        # Where should the widget be placed, left sidebar or right sidebar
        position: right
        type: tags
```

The optional values of pages include index, archive, category, tag and post. If they are not specified, all pages will display the widget by default.

For example, The widget of profile is only displayed on the home page, TOC directory widget is only displayed on the post page, and the other three widgets alway displayed, you can refer to my [site](https://www.welearn.net.cn).

----

其中 pages 可选值包含 index（首页）、 archive（归档）、 category（分类）、 tag（标签）、 post（正文），如若不填，则默认所有页面均显示该挂件。

例如 profile 个人简介挂件表示只在首页显示，toc 目录挂件表示只在正文页面显示，其余三个则表示所有页面均展示该挂件，实际效果可参考我的[网站](https://www.welearn.net.cn)。