### PR TITLE
fix(style): fix style of post navigation

### DIFF
--- a/include/style/article.styl
+++ b/include/style/article.styl
@@ -153,12 +153,12 @@ a
     &.article-nav-prev
         span
             text-align: left
-            width: 100%;
+            flex-shrink: 1
             word-wrap: break-word
             white-space: normal
     &.article-nav-next
         span
             text-align: right
-            width: 100%;
+            flex-shrink: 1
             word-wrap: break-word
             white-space: normal

--- a/include/style/article.styl
+++ b/include/style/article.styl
@@ -148,3 +148,17 @@ article
         
         a
             color: inherit
+
+a
+    &.article-nav-prev
+        span
+            text-align: left
+            width: 100%;
+            word-wrap: break-word
+            white-space: normal
+    &.article-nav-next
+        span
+            text-align: right
+            width: 100%;
+            word-wrap: break-word
+            white-space: normal


### PR DESCRIPTION
## Commit Message
fix(style): fix style of post navigation

## Commit Body
Fix style of post navigation for long title.  In released version, navigation will overflow the screen with a long title.

修复因标题过长而导致的文章导航样式问题。现时版本於手机等移动设备浏览时，若标题过长，导航提示可能会溢出屏幕。

## Demo
Here are some pages for demo.

此处提供两个页面以供参考。
[Kitcham's Blog - 为 ICARUS 而生的友情链接页面](https://blog.uiharu.top/archives/feat-icarus-links-page.html)
[Kitcham's Blog - 计算神经科学（一） —— 我们搞清楚自己的脑子了吗？](https://blog.uiharu.top/archives/computational-neuroscience-1-do-you-know-brain.html)
