### PR TITLE
feat(layout): add customization of article licensing block

### DIFF
--- a/layout/common/article.jsx
+++ b/layout/common/article.jsx
@@ -86,7 +86,7 @@ module.exports = class extends Component {
                     {/* Content/Excerpt */}
                     <div class="content" dangerouslySetInnerHTML={{ __html: index && page.excerpt ? page.excerpt : page.content }}></div>
                     {/* Licensing block */}
-                    {!index && article && article.licenses && Object.keys(article.licenses)
+                    {!index && !page.hide_license && article && article.licenses && Object.keys(article.licenses)
                         ? <ArticleLicensing.Cacheable page={page} config={config} helper={helper} /> : null}
                     {/* Tags */}
                     {!index && page.tags && page.tags.length ? <div class="article-tags size-small mb-4">


### PR DESCRIPTION
## Commit Message
feat(layout): add customization of article licensing block

## Commit Body
The feature allows users to customize invisibility of licensing block in specific pages.

该功能允许用户自定义是否於特定页面隐藏许可协议。

## Demo
Licensing block will be shown by default. Users may use front-matter below to hide licensing block.
```yaml
title: Icarus User Guide - Configuring the Theme
…
hide_license: true
…
---
