### PR TITLE
feat(layout): change date time format to locale string instead of UTC TZ time

### DIFF
--- a/layout/common/article.jsx
+++ b/layout/common/article.jsx
@@ -44,11 +44,11 @@ module.exports = class extends Component {
                         <div class="level-left">
                             {/* Creation Date */}
                             {page.date && <span class="level-item" dangerouslySetInnerHTML={{
-                                __html: _p('article.created_at', `<time dateTime="${date_xml(page.date)}" title="${date_xml(page.date)}">${date(page.date)}</time>`)
+                                __html: _p('article.created_at', `<time dateTime="${date_xml(page.date)}" title="${new Date(page.date).toLocaleString()}">${date(page.date)}</time>`)
                             }}></span>}
                             {/* Last Update Date */}
                             {page.updated && <span class="level-item" dangerouslySetInnerHTML={{
-                                __html: _p('article.updated_at', `<time dateTime="${date_xml(page.updated)}" title="${date_xml(page.updated)}">${date(page.updated)}</time>`)
+                                __html: _p('article.updated_at', `<time dateTime="${date_xml(page.updated)}" title="${new Date(page.updated).toLocaleString()}">${date(page.updated)}</time>`)
                             }}></span>}
                             {/* author */}
                             {page.author ? <span class="level-item"> {page.author} </span> : null}


### PR DESCRIPTION
### Description

We can get UTC TZ format time when we **hover** on relative time, it is not friendly, I suggest to change it to locale string.

### Before

![Before](https://user-images.githubusercontent.com/20182252/103065994-e9180600-45f2-11eb-968d-e43f3d0adf30.png)

### After

![After](https://user-images.githubusercontent.com/20182252/103065912-af46ff80-45f2-11eb-8ead-6321e56c68c3.png)