### PR TITLE
Remove extra quotes

### DIFF
--- a/source/_posts/en/Search-Plugins.md
+++ b/source/_posts/en/Search-Plugins.md
@@ -87,7 +87,7 @@ Please refer to it for a complete list of supported plugins and their configurat
 
     {% codeblock "Windows Command Prompt (CMD)" lang:cmd %}
     C:\Users\you> cd path/to/your/hexo/site
-    C:\Users\you> set HEXO_ALGOLIA_INDEXING_KEY="727fbd8c998fe419318fa350db6793ca"
+    C:\Users\you> set HEXO_ALGOLIA_INDEXING_KEY=727fbd8c998fe419318fa350db6793ca
     {% endcodeblock %}
 
    On Linux/macOS:

--- a/source/_posts/zh-CN/Search-Plugins.md
+++ b/source/_posts/zh-CN/Search-Plugins.md
@@ -93,7 +93,7 @@ providers:
 
     {% codeblock "Windows命令行(CMD)" lang:cmd %}
     C:\Users\you> cd path/to/your/hexo/site
-    C:\Users\you> set HEXO_ALGOLIA_INDEXING_KEY="727fbd8c998fe419318fa350db6793ca"
+    C:\Users\you> set HEXO_ALGOLIA_INDEXING_KEY=727fbd8c998fe419318fa350db6793ca
     {% endcodeblock %}
 
    Linux/macOS下：


### PR DESCRIPTION
The environment variable in the **set** is a string value. If you add quotation marks, the quotation marks will become part of the value, causing an error.
```
INFO  === Checking package dependencies ===
INFO  === Checking theme configurations ===
INFO  === Registering Hexo extensions ===
INFO  [hexo-algolia] Testing HEXO_ALGOLIA_INDEXING_KEY permissions.
ERROR [hexo-algolia] Invalid Application-ID or API key
ERROR >> You might have used an Admin Key or an invalid Key.
ERROR >> Read https://npmjs.com/hexo-algolia#security-concerns for more informations.
```