### PR TITLE
feat(layout): add option for updated time of posts

### DIFF
--- a/include/schema/common/article.json
+++ b/include/schema/common/article.json
@@ -40,6 +40,13 @@
             "default": true,
             "nullable": true
         },
+        "update_time": {
+            "type": ["boolean", "string"],
+            "description": "Whether to show updated time. For \"auto\", shows article update time only when page.updated is set and it is different from page.date",
+            "default": true,
+            "enum": [true, false, "auto"],
+            "nullable": true
+        },
         "licenses": {
             "$ref": "/misc/poly_links.json",
             "description": "Article licensing block",

--- a/layout/common/article.jsx
+++ b/layout/common/article.jsx
@@ -26,6 +26,9 @@ module.exports = class extends Component {
         const indexLaunguage = config.language || 'en';
         const language = page.lang || page.language || config.language || 'en';
         const cover = page.cover ? url_for(page.cover) : null;
+        const updateTime = article && article.update_time !== undefined ? article.update_time : true;
+        const isUpdated = page.updated && !moment(page.date).isSame(moment(page.updated));
+        const shouldShowUpdated = page.updated && ((updateTime === 'auto' && isUpdated) || updateTime === true);
 
         return <Fragment>
             {/* Main content */}
@@ -47,7 +50,7 @@ module.exports = class extends Component {
                                 __html: _p('article.created_at', `<time dateTime="${date_xml(page.date)}" title="${new Date(page.date).toLocaleString()}">${date(page.date)}</time>`)
                             }}></span>}
                             {/* Last Update Date */}
-                            {page.updated && <span class="level-item" dangerouslySetInnerHTML={{
+                            {shouldShowUpdated && <span class="level-item" dangerouslySetInnerHTML={{
                                 __html: _p('article.updated_at', `<time dateTime="${date_xml(page.updated)}" title="${new Date(page.updated).toLocaleString()}">${date(page.updated)}</time>`)
                             }}></span>}
                             {/* author */}


### PR DESCRIPTION
If the post's updated is same as date, hide the element of
updated time automatically.

Also provides a new config option to toggle this behavior.

Signed-off-by: Weida Hong <wdhongtw@gmail.com>