### PR TITLE
Make codeblock fold/unfold use a larger clickable area

### DIFF
--- a/include/style/codeblock.styl
+++ b/include/style/codeblock.styl
@@ -13,7 +13,7 @@ figure.highlight
     &.folded
         .highlight-body
             height: 0
-    
+
     .copy
         opacity: .7
 
@@ -89,6 +89,14 @@ figure.highlight
         vertical-align: inherit
         min-width: inherit
         border-radius: inherit
+
+figure.highlight.folded
+  figcaption
+    cursor: pointer
+
+figure.highlight.unfolded
+  figcaption
+    cursor: pointer
 
 /* ---------------------------------
  *        Fix Gist Snippet

--- a/include/style/codeblock.styl
+++ b/include/style/codeblock.styl
@@ -90,13 +90,9 @@ figure.highlight
         min-width: inherit
         border-radius: inherit
 
-figure.highlight.folded
-  figcaption
-    cursor: pointer
-
-figure.highlight.unfolded
-  figcaption
-    cursor: pointer
+figure.highlight.foldable
+  div.level-left
+    cursor: pointer  // clicking the codeblock filename can toggle folding 
 
 /* ---------------------------------
  *        Fix Gist Snippet

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -111,7 +111,7 @@
                 toggleFold(this, fold === 'folded');
             });
 
-            $('figure.highlight figcaption .fold').click(function() {
+            $('figure.highlight figcaption').click(function() {
                 const $code = $(this).closest('figure.highlight');
                 toggleFold($code.eq(0), !$code.hasClass('folded'));
             });

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -111,7 +111,7 @@
                 toggleFold(this, fold === 'folded');
             });
 
-            $('figure.highlight figcaption').click(function() {
+            $('figure.highlight figcaption .level-left').click(function() {
                 const $code = $(this).closest('figure.highlight');
                 toggleFold($code.eq(0), !$code.hasClass('folded'));
             });


### PR DESCRIPTION
Before this change, for codeblocks with folding enabled, users have to click the small arrow to toggle fold/unfold:
![2022-05-07_14-09](https://user-images.githubusercontent.com/1381301/167271797-ee82420d-1911-4175-92b3-2c5801e6d7ad.png)

I find it very difficult to click since it's too small.

After this PR, clicking anywhere in the div below would toggle fold/unfold:
![2022-05-07_15-38](https://user-images.githubusercontent.com/1381301/167274065-c78acd9c-e6ab-4115-867c-41610a97e9cc.png)

The hyperlink and copy button on the right is unaffected.

Also changed the cursor style to pointer, for this div.

When folding is disabled, the cursor style stays unchanged - this is a use case of https://github.com/ppoffice/hexo-theme-icarus/pull/1071


This is only my personal opinion, so feel free to dismiss it, and I can keep it in my own customization.

