### PR TITLE
Fix support for hashes that start with numbers

### DIFF
--- a/source/js/animation.js
+++ b/source/js/animation.js
@@ -52,7 +52,8 @@
         // jump to location.hash
         if (window.location.hash) {
             setTimeout(() => {
-                document.querySelector(window.location.hash).scrollIntoView({ behavior: 'smooth' });
+                // Use getElementById because querySelector does not support ids that start with numbers
+                document.getElementById(window.location.hash.substring(1)).scrollIntoView({ behavior: 'smooth' });
             }, i * 100);
         }
     });


### PR DESCRIPTION
QuerySelector does not work with ids that start with numbers:

https://stackoverflow.com/questions/20306204/using-queryselector-with-ids-that-are-numbers 

https://github.com/madrobby/zepto/issues/1333