### PR TITLE
feat(footer): added copyright

### DIFF
--- a/include/schema/common/footer.json
+++ b/include/schema/common/footer.json
@@ -4,6 +4,16 @@
     "description": "Page footer configurations",
     "type": "object",
     "properties": {
+        "copyright": {
+            "$ref": "/misc/copyright.json",
+            "description": "Copyright text",
+            "type": "string",
+            "examples": [
+                "© 2019",
+                "© 2019 - 2020",
+                "<a href=\"https://beian.miit.gov.cn/\" target=\"_blank\">粤ICP备1234567号</a>"
+            ]
+        },
         "links": {
             "$ref": "/misc/poly_links.json",
             "description": "Links to be shown on the right of the footer section",

--- a/layout/common/footer.jsx
+++ b/layout/common/footer.jsx
@@ -11,6 +11,7 @@ class Footer extends Component {
             siteYear,
             author,
             links,
+            copyright,
             showVisitorCounter,
             visitorCounterTitle
         } = this.props;
@@ -41,6 +42,7 @@ class Footer extends Component {
                             {showVisitorCounter ? <span id="busuanzi_container_site_uv"
                                 dangerouslySetInnerHTML={{ __html: visitorCounterTitle }}></span> : null}
                         </p>
+                        {copyright ? <p class="is-size-7" dangerouslySetInnerHTML={{ __html: copyright }}></p> : null}
                     </div>
                     <div class="level-end">
                         {Object.keys(links).length ? <div class="field has-addons">
@@ -84,6 +86,7 @@ module.exports = cacheComponent(Footer, 'common.footer', props => {
         siteYear: date(new Date(), 'YYYY'),
         author,
         links,
+        copyright: footer.copyright,
         showVisitorCounter: plugins && plugins.busuanzi === true,
         visitorCounterTitle: _p('plugin.visitor_count', '<span id="busuanzi_value_site_uv">0</span>')
     };

--- a/layout/common/footer.jsx
+++ b/layout/common/footer.jsx
@@ -86,7 +86,7 @@ module.exports = cacheComponent(Footer, 'common.footer', props => {
         siteYear: date(new Date(), 'YYYY'),
         author,
         links,
-        copyright: footer.copyright,
+        copyright: footer?.copyright ?? '',
         showVisitorCounter: plugins && plugins.busuanzi === true,
         visitorCounterTitle: _p('plugin.visitor_count', '<span id="busuanzi_value_site_uv">0</span>')
     };


### PR DESCRIPTION
Added custom copyright.

**Example:**

<img width="276" alt="image" src="https://user-images.githubusercontent.com/14297703/212642900-536ddd55-6ea4-4beb-bee5-7e2cd6831a2f.png">

> **Important!Important!Important!** In China, a filing number needs to be set at the bottom of the website for public access, otherwise it will not pass the filing audit.