### PR TITLE
Add "me" keyword to certain links

### DIFF
--- a/layout/widget/profile.jsx
+++ b/layout/widget/profile.jsx
@@ -10,7 +10,7 @@ class Profile extends Component {
         return <div class="level is-mobile is-multiline">
             {links.filter(link => typeof link === 'object').map(link => {
                 return <a class="level-item button is-transparent is-marginless"
-                    target="_blank" rel="noopener" title={link.name} href={link.url}>
+                    target="_blank" rel="me noopener" title={link.name} href={link.url}>
                     {'icon' in link ? <i class={link.icon}></i> : link.name}
                 </a>;
             })}
@@ -73,7 +73,7 @@ class Profile extends Component {
                     </div>
                 </nav>
                 {followLink ? <div class="level">
-                    <a class="level-item button is-primary is-rounded" href={followLink} target="_blank" rel="noopener">{followTitle}</a>
+                    <a class="level-item button is-primary is-rounded" href={followLink} target="_blank" rel="me noopener">{followTitle}</a>
                 </div> : null}
                 {socialLinks ? this.renderSocialLinks(socialLinks) : null}
             </div>


### PR DESCRIPTION
This pull request adds the `me` keyword to the `rel` attribute of certain hyperlinks in the profile widget, allowing users to verify that they are the owner of a page created with Icarus. See, for example, https://joinmastodon.org/verification.