### PR TITLE
fix(view): fix pjax support for mathjax

### DIFF
--- a/source/js/pjax.js
+++ b/source/js/pjax.js
@@ -32,11 +32,18 @@
     //     // TODO pace start loading animation
     // })
 
-    // // Listen for completion of Pjax
-    // document.addEventListener('pjax:complete', function() {
-    //     return;
-    //     // TODO pace stop loading animation
-    // })
+    // Listen for completion of Pjax
+    document.addEventListener('pjax:complete', () => {
+        // MathJax reload logic
+        if (window.MathJax) {
+            try {
+                window.MathJax.typesetPromise && window.MathJax.typesetPromise();
+            } catch (e) {
+                console.error('MathJax reload error:', e);
+            }
+        }
+        // TODO pace stop loading animation
+    });
 
     document.addEventListener('DOMContentLoaded', () => initPjax());
 }());


### PR DESCRIPTION
#### 修复问题
**#1327** ：使用 pjax 时 MathJax 未在新页面重新加载，从而导致数学公式无法在新页面渲染。

#### 解决方案
监听 `pjax:complete` 事件。当该事件触发时，判断是否已导入 MathJax。如果已导入，则调用 MathJax 的 `typesetPromise()` 方法来重新渲染数学公式。

-----

#### Problem Fixed
**#1327** : Math formulas not rendered in new pages because pjax banned the reloading of MathJax.

#### Solution
Listen on `pjax:complete` event. When the event triggered, see whether MathJax has been imported, then invoke `typesetPromise()` to re-render math formulas.
