### PR TITLE
Fix FOUC on PJAX navigation by removing data-pjax from main stylesheet

### DIFF
--- a/layout/common/head.jsx
+++ b/layout/common/head.jsx
@@ -168,7 +168,7 @@ module.exports = class extends Component {
             <link rel="stylesheet" href={iconcdn()} />
             {hlTheme ? <link data-pjax rel="stylesheet" href={cdn('highlight.js', '11.7.0', 'styles/' + hlTheme + '.css')} /> : null}
             <link rel="stylesheet" href={fontCssUrl[variant]} />
-            <link data-pjax rel="stylesheet" href={url_for('/css/' + variant + '.css')} />
+            <link rel="stylesheet" href={url_for('/css/' + variant + '.css')} />
             <Plugins site={site} config={config} helper={helper} page={page} head={true} />
 
             {adsenseClientId ? <script data-ad-client={adsenseClientId}


### PR DESCRIPTION
## Summary

Fixes #1388

The main stylesheet `<link>` tag in `layout/common/head.jsx` has the `data-pjax` attribute, which causes PJAX to replace it on every navigation. This forces the browser to re-download and re-parse the ~266KB CSS file, resulting in a full flash of unstyled content (FOUC) for ~2 seconds on every page click.

The variant stylesheet (`default.css` or `cyberpunk.css`) is identical across all pages, so there is no reason for PJAX to replace it during navigation.

## Change

```diff
- <link data-pjax rel="stylesheet" href={url_for('/css/' + variant + '.css')} />
+ <link rel="stylesheet" href={url_for('/css/' + variant + '.css')} />
```

## Test plan

- [x] Hard refresh — initial load animation works as before
- [x] Click between nav links (Home, Archives, Categories, Tags, About) — no unstyled flash
- [x] Page content and layout renders correctly on all pages
- [x] Verified with Hexo 7.3.0 and Icarus 6.1.1